### PR TITLE
Handle missing month column and add entries vs exits charts

### DIFF
--- a/home.py
+++ b/home.py
@@ -163,6 +163,10 @@ with st.sidebar:
         options=meses_lista,
         default=["Todos"],
     )
+    if "Todos" in meses_sel:
+        meses_sel = list(range(1, 13))
+    else:
+        meses_sel = [MES_PARA_NUM[m] for m in meses_sel]
 
     st.markdown("---")
     st.markdown(
@@ -266,8 +270,7 @@ if tipo_relatorio == "📁 Fiscal" and relatorio_escolhido == "Apuração de Tri
                 f"<div class='card-destaque-green'>Crédito PIS/COFINS a Transportar<br><span style='font-size:1.15em;'>{format_brl(pis_credito)}</span></div>",
                 unsafe_allow_html=True
             )
-
-st.markdown("---")
+    st.markdown("---")
 st.subheader("Relatórios disponíveis")
 
 # RESTANTE: idêntico ao anterior...

--- a/home.py
+++ b/home.py
@@ -4,7 +4,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import streamlit as st
 import pandas as pd
-import plotly.express as px
 
 from app.meses import MESES_PT, MES_PARA_NUM
 
@@ -156,17 +155,16 @@ with st.sidebar:
         index=0 if anos else 0,
     )
 
-    meses_lista = [MESES_PT[m] for m in meses] if meses else [MESES_PT[1]]
-    meses_lista = ["Todos"] + meses_lista
+    meses_lista = ["Todos os meses"] + [MESES_PT[m] for m in range(1, 13)]
     meses_sel = st.multiselect(
         "Meses",
         options=meses_lista,
-        default=["Todos"],
+        default=["Todos os meses"],
     )
-    if "Todos" in meses_sel:
+    if "Todos os meses" in meses_sel or not meses_sel:
         meses_sel = list(range(1, 13))
     else:
-        meses_sel = [MES_PARA_NUM[m] for m in meses_sel]
+        meses_sel = sorted({MES_PARA_NUM[m] for m in meses_sel})
 
     st.markdown("---")
     st.markdown(
@@ -279,36 +277,14 @@ if tipo_relatorio == "📁 Fiscal":
         resumo_mensal = resumo_mensal_full  # já carregado acima para evitar cálculo duplo
         if resumo_mensal:
             for linha in resumo_mensal:
-                with st.expander(f"{linha['Mês']} {linha['Ano']}", expanded=(linha['Mês'] == MESES_PT[datas.dt.month.min()])):
-                    col_a, col_b, col_c = st.columns(3)
-                    col_a.markdown(f"<div class='card blue'>TOTAL ENTRADAS<br><b>{format_brl(linha['Entradas (Revenda + Frete)'])}</b></div>", unsafe_allow_html=True)
-                    col_b.markdown(f"<div class='card blue'>TOTAL SAÍDAS<br><b>{format_brl(linha['Saídas'])}</b></div>", unsafe_allow_html=True)
-                    resultado = linha['Resultado Líquido']
-                    cor_resultado = "green" if resultado >= 0 else "red"
-                    col_c.markdown(f"<div class='card {cor_resultado}'>RESULTADO<br><b>{format_brl(resultado)}</b></div>", unsafe_allow_html=True)
-
-                    view_mode = st.radio(
-                        "Ver",
-                        ["Por mês", "Total"],
-                        key=f"view_{linha['Ano']}_{linha['Mês']}",
-                        horizontal=True,
+                with st.expander(
+                    f"{linha['Mês']} {linha['Ano']}",
+                    expanded=(linha['Mês'] == MESES_PT[datas.dt.month.min()]),
+                ):
+                    st.markdown(
+                        "<div class='titulo-apuracao'>APURAÇÃO ICMS</div>",
+                        unsafe_allow_html=True,
                     )
-                    if view_mode == "Por mês":
-                        valores = [
-                            linha["Entradas (Revenda + Frete)"],
-                            linha["Saídas"],
-                        ]
-                    else:
-                        total_ent = sum(l["Entradas (Revenda + Frete)"] for l in resumo_mensal)
-                        total_sai = sum(l["Saídas"] for l in resumo_mensal)
-                        valores = [total_ent, total_sai]
-                    df_bar = pd.DataFrame({"Tipo": ["Entradas", "Saídas"], "Valor": valores})
-                    fig = px.bar(df_bar, x="Tipo", y="Valor", text="Valor", template="plotly_dark")
-                    fig.update_traces(texttemplate="R$ %{y:,.2f}", textposition="outside")
-                    fig.update_layout(margin=dict(t=30, b=10))
-                    st.plotly_chart(fig, use_container_width=True)
-
-                    st.markdown("<div class='titulo-apuracao'>APURAÇÃO ICMS</div>", unsafe_allow_html=True)
                     c1, c2, c3, c4 = st.columns(4)
                     c1.markdown(f"<div class='card'>ICMS ENTRADA<br><b>{format_brl(linha['ICMS Entradas'])}</b></div>", unsafe_allow_html=True)
                     c2.markdown(f"<div class='card'>ICMS SAÍDA<br><b>{format_brl(linha['ICMS Saídas'])}</b></div>", unsafe_allow_html=True)

--- a/relatorio_fiscal.py
+++ b/relatorio_fiscal.py
@@ -96,8 +96,12 @@ def calcular_resumo_fiscal_mes_a_mes(df, ano_sel, meses_sel, considerar_acumulo_
         df["Data Emissão"] = pd.to_datetime(df["Data Emissão"], format="%d/%m/%Y", errors="coerce")
         df = df[df["Data Emissão"].dt.year == ano_sel]
 
-        if meses_sel and "Todos" not in meses_sel:
-            meses_num = [MES_PARA_NUM.get(m, None) for m in meses_sel if m in MES_PARA_NUM]
+        if meses_sel:
+            if all(isinstance(m, int) for m in meses_sel):
+                meses_num = meses_sel
+            else:
+                meses_num = [MES_PARA_NUM.get(m, None) for m in meses_sel if m in MES_PARA_NUM]
+            meses_num = [m for m in meses_num if m]
         else:
             meses_num = sorted(df["Data Emissão"].dt.month.dropna().unique())
 
@@ -209,7 +213,7 @@ def mostrar_resumo_fiscal(df, ano_sel=None, meses_sel=None):
 
     # Cards de ICMS
     todos_meses = calcular_resumo_fiscal_mes_a_mes(
-        df, ano_sel, [MESES_PT[m] for m in range(1, 13)]
+        df, ano_sel, list(range(1, 13))
     )
     if todos_meses:
         ultimo = todos_meses[-1]
@@ -292,8 +296,8 @@ def simulador_icms_manual(df=None, ano_sel=None, meses_sel=None):
         if meses_sel:
             meses_param = meses_sel
         else:
-            meses_param = [MESES_PT[m] for m in range(1, 13)]
-        
+            meses_param = list(range(1, 13))
+
         todos_meses = calcular_resumo_fiscal_mes_a_mes(df, ano_sel, meses_param)
         if todos_meses:
             credito_acumulado = todos_meses[-1].get('Crédito ICMS Transportado', 0.0)
@@ -655,7 +659,7 @@ def simulador_pis_cofins_manual(df=None, ano_sel=None, meses_sel=None):
         if meses_sel:
             meses_param = meses_sel
         else:
-            meses_param = [MESES_PT[m] for m in range(1, 13)]
+            meses_param = list(range(1, 13))
         todos_meses = calcular_resumo_fiscal_mes_a_mes(df, ano_sel, meses_param)
         if todos_meses:
             credito_acumulado = todos_meses[-1].get('Crédito PIS/COFINS Transportado', 0.0)

--- a/relatorio_graficos.py
+++ b/relatorio_graficos.py
@@ -232,10 +232,30 @@ def mostrar_entradas_saidas(
 
     mostrar_por_mes = set(meses_num) == set(range(1, 13))
     idx = range(1, 13) if mostrar_por_mes else sorted(meses_num)
-    ent_mes = df_ent.groupby(df_ent["Data Emissão"].dt.month)["Valor Líquido"].sum().reindex(idx, fill_value=0)
-    sai_mes = df_sai.groupby(df_sai["Data Emissão"].dt.month)["Valor Líquido"].sum().reindex(idx, fill_value=0)
-    df_mes = pd.concat([ent_mes, sai_mes], axis=1).fillna(0).reset_index()
-    df_mes.columns = ["mes", "Entradas", "Saídas"]
+
+    ent_mes = (
+        df_ent.groupby(df_ent["Data Emissão"].dt.month)["Valor Líquido"].sum()
+        .reindex(idx, fill_value=0)
+    )
+    sai_mes = (
+        df_sai.groupby(df_sai["Data Emissão"].dt.month)["Valor Líquido"].sum()
+        .reindex(idx, fill_value=0)
+    )
+
+    df_mes = pd.concat([ent_mes, sai_mes], axis=1).fillna(0)
+    df_mes.index.name = "mes"
+    df_mes.columns = ["Entradas", "Saídas"]
+    df_mes = df_mes.reset_index()
+
+    if "mes" not in df_mes.columns:
+        if "Mês" in df_mes.columns:
+            inv = {v: k for k, v in MESES_PT.items()}
+            df_mes["mes"] = df_mes["Mês"].map(inv)
+        elif "Data Emissão" in df_mes.columns:
+            df_mes["mes"] = pd.to_datetime(
+                df_mes["Data Emissão"], errors="coerce"
+            ).dt.month
+
     df_mes["Mês"] = df_mes["mes"].map(MESES_PT)
     df_mes = df_mes.sort_values("mes")
 

--- a/relatorio_graficos.py
+++ b/relatorio_graficos.py
@@ -183,8 +183,114 @@ def create_modern_bar_chart(df, x_col, y_col, color_col, title, color_map, templ
         zerolinewidth=2,
         zerolinecolor='rgba(255,255,255,0.2)'
     )
-    
+
     return fig
+
+
+def mostrar_entradas_saidas(
+    df_entradas: pd.DataFrame,
+    df_saidas: pd.DataFrame,
+    anos: list[int],
+    meses: list[int],
+    somente_tributaveis: bool = False,
+):
+    """Exibe gráfico comparativo de Entradas x Saídas.
+
+    Parâmetros
+    ----------
+    df_entradas, df_saidas : DataFrames das notas.
+    anos : lista contendo o ano selecionado.
+    meses : lista de números dos meses (1-12).
+    somente_tributaveis : quando True, filtra apenas
+        entradas classificadas como Mercadoria para Revenda ou Frete.
+    """
+
+    ano_sel = anos[0] if isinstance(anos, (list, tuple)) else anos
+    meses_num = meses if meses else list(range(1, 13))
+
+    def prepara(df: pd.DataFrame, is_entrada: bool) -> pd.DataFrame:
+        df = df.copy()
+        df["Data Emissão"] = pd.to_datetime(
+            df["Data Emissão"], format="%d/%m/%Y", errors="coerce"
+        )
+        df = df[
+            (df["Data Emissão"].dt.year == ano_sel)
+            & (df["Data Emissão"].dt.month.isin(meses_num))
+        ]
+        if is_entrada and somente_tributaveis:
+            df = df[
+                df["Classificação"].str.contains(
+                    r"(Mercadoria para Revenda|Frete)",
+                    case=False,
+                    na=False,
+                )
+            ]
+        return df
+
+    df_ent = prepara(df_entradas, True)
+    df_sai = prepara(df_saidas, False)
+
+    ent_mes = df_ent.groupby(df_ent["Data Emissão"].dt.month)["Valor Líquido"].sum()
+    sai_mes = df_sai.groupby(df_sai["Data Emissão"].dt.month)["Valor Líquido"].sum()
+    df_mes = pd.concat([ent_mes, sai_mes], axis=1).fillna(0)
+    df_mes.columns = ["Entradas", "Saídas"]
+    df_mes = df_mes.reset_index()
+
+    col0 = df_mes.columns[0]
+    df_mes = df_mes.rename(columns={col0: "mes"})
+    if "mes" not in df_mes.columns:
+        if "Mês" in df_mes.columns:
+            inv = {v: k for k, v in MESES_PT.items()}
+            df_mes["mes"] = df_mes["Mês"].map(inv)
+        elif "Data Emissão" in df_mes.columns:
+            df_mes["mes"] = pd.to_datetime(
+                df_mes["Data Emissão"], errors="coerce"
+            ).dt.month
+
+    df_mes["Mês"] = df_mes["mes"].map(MESES_PT)
+    df_mes = df_mes.sort_values("mes")
+
+    st.markdown(
+        '<h2 class="section-title">Entradas x Saídas por Período</h2>',
+        unsafe_allow_html=True,
+    )
+
+    mostrar_por_mes = set(meses_num) == set(range(1, 13))
+    if mostrar_por_mes:
+        df_plot = df_mes.melt(
+            id_vars=["Mês"],
+            value_vars=["Entradas", "Saídas"],
+            var_name="Tipo",
+            value_name="Valor",
+        )
+        df_plot["LabelAbbr"] = df_plot["Valor"].apply(abbr_format)
+        fig_es = create_modern_bar_chart(
+            df_plot,
+            "Mês",
+            "Valor",
+            "Tipo",
+            "",
+            {"Entradas": "#1f77b4", "Saídas": "#ff7f0e"},
+        )
+    else:
+        total_ent = df_mes["Entradas"].sum()
+        total_sai = df_mes["Saídas"].sum()
+        df_total = pd.DataFrame(
+            {"Tipo": ["Entradas", "Saídas"], "Valor": [total_ent, total_sai]}
+        )
+        df_total["LabelAbbr"] = df_total["Valor"].apply(abbr_format)
+        fig_es = create_modern_bar_chart(
+            df_total,
+            "Tipo",
+            "Valor",
+            "Tipo",
+            "",
+            {"Entradas": "#1f77b4", "Saídas": "#ff7f0e"},
+        )
+
+    st.plotly_chart(fig_es, use_container_width=True)
+
+    return df_mes
 
 def create_modern_pie_chart(df, names_col, values_col, title):
     """Cria gráfico de pizza com design moderno e melhor contraste"""
@@ -241,7 +347,7 @@ def create_modern_pie_chart(df, names_col, values_col, title):
 def mostrar_dashboard(df_entradas: pd.DataFrame,
                       df_saidas: pd.DataFrame,
                       anos: list[int],
-                      meses: list[str]):
+                      meses: list[int]):
 
     # CSS personalizado para o dashboard
     st.markdown("""
@@ -296,7 +402,7 @@ def mostrar_dashboard(df_entradas: pd.DataFrame,
 
     # 1) Período
     ano_sel = anos[0] if isinstance(anos, (list, tuple)) else anos
-    meses_num = list(range(1, 13)) if "Todos" in meses else [MES_PARA_NUM[m] for m in meses if m in MES_PARA_NUM]
+    meses_num = meses if meses else list(range(1, 13))
 
     # 2) Filtrar
     def filtrar(df: pd.DataFrame) -> pd.DataFrame:
@@ -317,27 +423,7 @@ def mostrar_dashboard(df_entradas: pd.DataFrame,
 
     st.markdown(create_kpi_cards_html(total_ent, total_sai, saldo), unsafe_allow_html=True)
 
-    st.markdown('<h2 class="section-title">Entradas x Saídas por Período</h2>', unsafe_allow_html=True)
-    modo_es = st.radio("Ver", ["Por mês", "Total"], horizontal=True)
-    ent_mes = df_ent.groupby(df_ent["Data Emissão"].dt.month)["Valor Líquido"].sum()
-    sai_mes = df_sai.groupby(df_sai["Data Emissão"].dt.month)["Valor Líquido"].sum()
-    df_mes = pd.concat([ent_mes, sai_mes], axis=1).fillna(0)
-    df_mes.columns = ["Entradas", "Saídas"]
-    df_mes = df_mes.reset_index().rename(columns={"index": "mes"})
-    df_mes["Mês"] = df_mes["mes"].map(MESES_PT)
-    df_mes = df_mes.sort_values("mes")
-
-    if modo_es == "Por mês":
-        df_plot = df_mes.melt(id_vars=["Mês"], value_vars=["Entradas", "Saídas"], var_name="Tipo", value_name="Valor")
-        df_plot["LabelAbbr"] = df_plot["Valor"].apply(abbr_format)
-        fig_es = create_modern_bar_chart(df_plot, "Mês", "Valor", "Tipo", "", {"Entradas": "#1f77b4", "Saídas": "#ff7f0e"})
-    else:
-        total_ent = df_mes["Entradas"].sum()
-        total_sai = df_mes["Saídas"].sum()
-        df_total = pd.DataFrame({"Tipo": ["Entradas", "Saídas"], "Valor": [total_ent, total_sai]})
-        df_total["LabelAbbr"] = df_total["Valor"].apply(abbr_format)
-        fig_es = create_modern_bar_chart(df_total, "Tipo", "Valor", "Tipo", "", {"Entradas": "#1f77b4", "Saídas": "#ff7f0e"})
-    st.plotly_chart(fig_es, use_container_width=True)
+    mostrar_entradas_saidas(df_ent, df_sai, [ano_sel], meses_num)
 
     # 1) Mercadorias por Estado
     st.markdown('<h2 class="section-title">Mercadorias por Estado</h2>', unsafe_allow_html=True)
@@ -378,10 +464,9 @@ def mostrar_dashboard(df_entradas: pd.DataFrame,
     # 3) ICMS
     st.markdown('<h2 class="section-title">Crédito x Débito de ICMS</h2>', unsafe_allow_html=True)
     df_all = pd.concat([df_ent, df_sai], ignore_index=True)
-    rel_ic = calcular_resumo_fiscal_mes_a_mes(df_all, ano_sel, meses)
+    rel_ic = calcular_resumo_fiscal_mes_a_mes(df_all, ano_sel, meses_num)
     df_ic = pd.DataFrame(rel_ic)
-    df_ic["mes_num"] = df_ic["Mês"].map(MES_PARA_NUM)
-    df_ic["Período"] = df_ic["Ano"].astype(str) + "-" + df_ic["mes_num"].apply(lambda m: f"{m:02d}")
+    df_ic["Período"] = df_ic["Ano"].astype(str) + "-" + df_ic["Mês"].map(MES_PARA_NUM).apply(lambda m: f"{m:02d}")
     df_ic_long = df_ic.melt(
         id_vars=["Período"],
         value_vars=["ICMS Entradas","ICMS Saídas"],
@@ -399,10 +484,9 @@ def mostrar_dashboard(df_entradas: pd.DataFrame,
 
     # 4) PIS & COFINS
     st.markdown('<h2 class="section-title">Crédito x Débito de PIS/COFINS</h2>', unsafe_allow_html=True)
-    rel_pc = calcular_resumo_fiscal_mes_a_mes(df_all, ano_sel, meses)
+    rel_pc = calcular_resumo_fiscal_mes_a_mes(df_all, ano_sel, meses_num)
     df_pc = pd.DataFrame(rel_pc)
-    df_pc["mes_num"] = df_pc["Mês"].map(MES_PARA_NUM)
-    df_pc["Período"] = df_pc["Ano"].astype(str) + "-" + df_pc["mes_num"].apply(lambda m: f"{m:02d}")
+    df_pc["Período"] = df_pc["Ano"].astype(str) + "-" + df_pc["Mês"].map(MES_PARA_NUM).apply(lambda m: f"{m:02d}")
     df_pc_long = df_pc.melt(
         id_vars=["Período"],
         value_vars=["PIS/COFINS Entradas","PIS/COFINS Saídas"],


### PR DESCRIPTION
## Summary
- drive Entradas x Saídas chart mode from month filter and drop radio toggle
- add "Todos" month option and convert selection to numeric months
- allow fiscal summaries to accept numeric month lists

## Testing
- `python -m py_compile home.py relatorio_graficos.py relatorio_fiscal.py`


------
https://chatgpt.com/codex/tasks/task_e_689b705e674c832691694294ea347920