### PR TITLE
Remover rádios e alinhar gráficos ao filtro de meses

### DIFF
--- a/relatorio_fiscal.py
+++ b/relatorio_fiscal.py
@@ -96,10 +96,10 @@ def calcular_resumo_fiscal_mes_a_mes(df, ano_sel, meses_sel, considerar_acumulo_
         df["Data Emissão"] = pd.to_datetime(df["Data Emissão"], format="%d/%m/%Y", errors="coerce")
         df = df[df["Data Emissão"].dt.year == ano_sel]
 
-        if meses_sel and "Todos" not in meses_sel:
+        if meses_sel and "Todos os meses" not in meses_sel:
             meses_num = [MES_PARA_NUM.get(m, None) for m in meses_sel if m in MES_PARA_NUM]
         else:
-            meses_num = sorted(df["Data Emissão"].dt.month.dropna().unique())
+            meses_num = list(range(1, 13))
 
         credito_icms_acumulado = 0.0
         credito_pis_cofins_acumulado = 0.0


### PR DESCRIPTION
## Summary
- Simplify sidebar using “Todos os meses” to expand selection to all 12 months
- Mostrar entradas/saídas decide entre gráfico mensal ou total automaticamente e higieniza valores
- Dashboard e relatórios fiscais deixam de exibir gráfico no módulo fiscal e usam títulos dinâmicos

## Testing
- `python -m py_compile home.py relatorio_fiscal.py relatorio_graficos.py`


------
https://chatgpt.com/codex/tasks/task_e_689b805369cc8326acd0d12d4dbc3a10