### PR TITLE
feat: add manual projection for fiscal simulators

### DIFF
--- a/relatorio_fiscal.py
+++ b/relatorio_fiscal.py
@@ -263,614 +263,126 @@ def mostrar_resumo_fiscal(df, ano_sel=None, meses_sel=None):
         mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
 
-def format_currency_input(value):
-    """Formata valor para exibição com máscara de moeda"""
-    if value == 0:
-        return ""
-    return f"{value:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+def _ultimo_mes_vigente(df):
+    datas = pd.to_datetime(df.get("Data Emissão", pd.Series([])), format="%d/%m/%Y", errors="coerce") if df is not None else pd.Series([], dtype="datetime64[ns]")
+    max_data = datas.max()
+    if pd.isna(max_data):
+        hoje = pd.Timestamp.today()
+        return hoje.year, hoje.month
+    return int(max_data.year), int(max_data.month)
+
+
+def _meses_restantes_do_ano(ano, mes_inicio):
+    return [(ano, m) for m in range(mes_inicio, 13)]
+
+
+def _credito_acumulado_atual(df, ano, mes_vig, imposto):
+    if df is None or df.empty or mes_vig <= 1:
+        return 0.0
+    meses_prev = list(range(1, mes_vig))
+    resumo = calcular_resumo_fiscal_mes_a_mes(df, ano, meses_prev)
+    if not resumo:
+        return 0.0
+    ultimo = resumo[-1]
+    if imposto == "icms":
+        return ultimo.get("Crédito ICMS Transportado", 0.0) or 0.0
+    return ultimo.get("Crédito PIS/COFINS Transportado", 0.0) or 0.0
+
+
+def _rollforward(credito_inicial, creditos, debitos, periodos):
+    resultados = []
+    credito_atual = credito_inicial
+    for (ano, mes), cred, deb in zip(periodos, creditos, debitos):
+        consumo = min(deb, cred + credito_atual)
+        a_pagar = deb - consumo
+        credito_final = max(cred + credito_atual - consumo, 0.0)
+        resultados.append(
+            {
+                "Período": f"{ano}-{mes:02d}",
+                "Ano": ano,
+                "Mês": MESES_PT[mes],
+                "Crédito Inicial": credito_atual,
+                "Crédito do Mês": cred,
+                "Débito do Mês": deb,
+                "A Pagar": a_pagar,
+                "Crédito Final": credito_final,
+            }
+        )
+        credito_atual = credito_final
+    return resultados
+
 
 def simulador_icms_manual(df=None, ano_sel=None, meses_sel=None):
-    st.header("Simulação Manual de Créditos e Débitos de ICMS")
-
-    # Inicializar valores no session_state se não existirem
-    if 'entrada_4_text' not in st.session_state:
-        st.session_state.entrada_4_text = ""
-    if 'entrada_7_text' not in st.session_state:
-        st.session_state.entrada_7_text = ""
-    if 'entrada_12_text' not in st.session_state:
-        st.session_state.entrada_12_text = ""
-    if 'entrada_19_text' not in st.session_state:
-        st.session_state.entrada_19_text = ""
-    if 'saida_12_text' not in st.session_state:
-        st.session_state.saida_12_text = ""
-    if 'saida_11_text' not in st.session_state:
-        st.session_state.saida_11_text = ""
-    if 'saida_19_text' not in st.session_state:
-        st.session_state.saida_19_text = ""
-    if 'simulacao_executada' not in st.session_state:
-        st.session_state.simulacao_executada = False
-
-    # Puxar crédito acumulado do último mês, se DataFrame for fornecido
-    credito_acumulado = 0.0
-    if df is not None and ano_sel is not None:
-        if meses_sel:
-            meses_param = meses_sel
-        else:
-            meses_param = list(range(1, 13))
-
-        todos_meses = calcular_resumo_fiscal_mes_a_mes(df, ano_sel, meses_param)
-        if todos_meses:
-            credito_acumulado = todos_meses[-1].get('Crédito ICMS Transportado', 0.0)
-
-    # Converter valores de texto para float
-    entrada_4 = moeda_to_float(st.session_state.entrada_4_text)
-    entrada_7 = moeda_to_float(st.session_state.entrada_7_text)
-    entrada_12 = moeda_to_float(st.session_state.entrada_12_text)
-    entrada_19 = moeda_to_float(st.session_state.entrada_19_text)
-    saida_12 = moeda_to_float(st.session_state.saida_12_text)
-    saida_11 = moeda_to_float(st.session_state.saida_11_text)
-    saida_19 = moeda_to_float(st.session_state.saida_19_text)
-
-    # 1. CARDS DE INPUTS LADO A LADO
-    col_entradas, col_saidas = st.columns(2, gap="large")
-
-    with col_entradas:
-        st.markdown(
-            """
-            <div style="
-                background: #1a2433;
-                border-radius: 12px;
-                padding: 20px;
-                border: 1px solid #2c3e50;
-            ">
-                <h3 style="color: white; margin: 0 0 16px 0; font-size: 1.1em; font-weight: bold;">
-                    Entradas — Simulação de Créditos de ICMS
-                </h3>
-            """,
-            unsafe_allow_html=True
-        )
-        
-        # Campo 4%
-        st.session_state.entrada_4_text = st.text_input(
-            "4%", 
-            value=st.session_state.entrada_4_text,
-            key="input_entrada_4_text",
-            placeholder="Ex: 10000,00"
-        )
-        if st.session_state.entrada_4_text:
-            st.markdown(f"<div style='color: #27ae60; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💰 {moeda_format(st.session_state.entrada_4_text)}</div>", unsafe_allow_html=True)
-        
-        # Campo 7%
-        st.session_state.entrada_7_text = st.text_input(
-            "7%", 
-            value=st.session_state.entrada_7_text,
-            key="input_entrada_7_text",
-            placeholder="Ex: 5000,50"
-        )
-        if st.session_state.entrada_7_text:
-            st.markdown(f"<div style='color: #27ae60; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💰 {moeda_format(st.session_state.entrada_7_text)}</div>", unsafe_allow_html=True)
-        
-        # Campo 12%
-        st.session_state.entrada_12_text = st.text_input(
-            "12%", 
-            value=st.session_state.entrada_12_text,
-            key="input_entrada_12_text",
-            placeholder="Ex: 25000,75"
-        )
-        if st.session_state.entrada_12_text:
-            st.markdown(f"<div style='color: #27ae60; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💰 {moeda_format(st.session_state.entrada_12_text)}</div>", unsafe_allow_html=True)
-        
-        # Campo 19%
-        st.session_state.entrada_19_text = st.text_input(
-            "19%", 
-            value=st.session_state.entrada_19_text,
-            key="input_entrada_19_text",
-            placeholder="Ex: 15000,00"
-        )
-        if st.session_state.entrada_19_text:
-            st.markdown(f"<div style='color: #27ae60; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💰 {moeda_format(st.session_state.entrada_19_text)}</div>", unsafe_allow_html=True)
-        
-        st.markdown("</div>", unsafe_allow_html=True)
-
-    with col_saidas:
-        st.markdown(
-            """
-            <div style="
-                background: #1a2433;
-                border-radius: 12px;
-                padding: 20px;
-                border: 1px solid #2c3e50;
-            ">
-                <h3 style="color: white; margin: 0 0 16px 0; font-size: 1.1em; font-weight: bold;">
-                    Saídas — Simulação de Débitos de ICMS
-                </h3>
-            """,
-            unsafe_allow_html=True
-        )
-        
-        # Campo 12%
-        st.session_state.saida_12_text = st.text_input(
-            "12%", 
-            value=st.session_state.saida_12_text,
-            key="input_saida_12_text",
-            placeholder="Ex: 30000,00"
-        )
-        if st.session_state.saida_12_text:
-            st.markdown(f"<div style='color: #e74c3c; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💸 {moeda_format(st.session_state.saida_12_text)}</div>", unsafe_allow_html=True)
-        
-        # Campo 11% PROTEGE
-        st.session_state.saida_11_text = st.text_input(
-            "11% PROTEGE", 
-            value=st.session_state.saida_11_text,
-            key="input_saida_11_text",
-            placeholder="Ex: 8000,25"
-        )
-        if st.session_state.saida_11_text:
-            st.markdown(f"<div style='color: #e74c3c; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💸 {moeda_format(st.session_state.saida_11_text)}</div>", unsafe_allow_html=True)
-        
-        # Campo 19%
-        st.session_state.saida_19_text = st.text_input(
-            "19%", 
-            value=st.session_state.saida_19_text,
-            key="input_saida_19_text",
-            placeholder="Ex: 12000,80"
-        )
-        if st.session_state.saida_19_text:
-            st.markdown(f"<div style='color: #e74c3c; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💸 {moeda_format(st.session_state.saida_19_text)}</div>", unsafe_allow_html=True)
-        
-        st.markdown("</div>", unsafe_allow_html=True)
-
-    # 2. BOTÃO DE SIMULAÇÃO CENTRALIZADO E PROFISSIONAL
-    st.markdown("<br>", unsafe_allow_html=True)
-    
-    # Verificar se há pelo menos um valor preenchido
-    tem_valores = any([
-        st.session_state.entrada_4_text, st.session_state.entrada_7_text,
-        st.session_state.entrada_12_text, st.session_state.entrada_19_text,
-        st.session_state.saida_12_text, st.session_state.saida_11_text,
-        st.session_state.saida_19_text
-    ])
-    
-    # Container centralizado para o botão
-    col1, col2, col3 = st.columns([1, 2, 1])
-    
-    with col2:
-        # Botão com estilo profissional adaptado à estética do script
-        if tem_valores:
-            botao_html = """
-            <div style="text-align: center; margin: 20px 0;">
-                <style>
-                    .btn-simular {
-                        background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
-                        border: 2px solid #1a2433;
-                        border-radius: 12px;
-                        color: white;
-                        padding: 16px 40px;
-                        font-size: 1.1em;
-                        font-weight: bold;
-                        cursor: pointer;
-                        transition: all 0.3s ease;
-                        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-                        text-transform: uppercase;
-                        letter-spacing: 1px;
-                        width: 100%;
-                        max-width: 300px;
-                    }
-                    .btn-simular:hover {
-                        background: linear-gradient(135deg, #34495e 0%, #2c3e50 100%);
-                        transform: translateY(-2px);
-                        box-shadow: 0 6px 16px rgba(0,0,0,0.25);
-                        border-color: #27ae60;
-                    }
-                    .btn-simular:active {
-                        transform: translateY(0);
-                        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-                    }
-                </style>
-            </div>
-            """
-            st.markdown(botao_html, unsafe_allow_html=True)
-            
-            simular = st.button(
-                "🔄 EXECUTAR SIMULAÇÃO",
-                key="btn_simular",
-                use_container_width=True,
-                type="primary"
-            )
-            
-            if simular:
-                st.session_state.simulacao_executada = True
-                st.success("✅ Simulação executada com sucesso!")
-        else:
+    st.header("Simulação Manual de ICMS")
+    ano_vig, mes_vig = _ultimo_mes_vigente(df if df is not None else pd.DataFrame())
+    credito_inicial = _credito_acumulado_atual(df, ano_vig, mes_vig, "icms")
+    st.markdown(f"Mês vigente: **{MESES_PT[mes_vig]} / {ano_vig}**")
+    st.markdown(f"Crédito acumulado inicial: **{format_brl(credito_inicial)}**")
+    meses = _meses_restantes_do_ano(ano_vig, mes_vig)
+    valores = {}
+    for ano, mes in meses:
+        with st.expander(f"{MESES_PT[mes]}/{ano}", expanded=(mes == mes_vig)):
+            col_e, col_s = st.columns(2)
+            with col_e:
+                e4 = st.number_input("Entrada 4%", min_value=0.0, key=f"icms_{ano}_{mes}_e4")
+                e7 = st.number_input("Entrada 7%", min_value=0.0, key=f"icms_{ano}_{mes}_e7")
+                e12 = st.number_input("Entrada 12%", min_value=0.0, key=f"icms_{ano}_{mes}_e12")
+                e19 = st.number_input("Entrada 19%", min_value=0.0, key=f"icms_{ano}_{mes}_e19")
+            with col_s:
+                s11 = st.number_input("Saída 11%", min_value=0.0, key=f"icms_{ano}_{mes}_s11")
+                s12 = st.number_input("Saída 12%", min_value=0.0, key=f"icms_{ano}_{mes}_s12")
+                s19 = st.number_input("Saída 19%", min_value=0.0, key=f"icms_{ano}_{mes}_s19")
+            valores[(ano, mes)] = (e4, e7, e12, e19, s11, s12, s19)
+    if st.button("Simular projeção", key="btn_icms_proj"):
+        creditos, debitos, periodos = [], [], []
+        for (ano, mes), (e4, e7, e12, e19, s11, s12, s19) in valores.items():
+            creditos.append(e4 * 0.04 + e7 * 0.07 + e12 * 0.12 + e19 * 0.19)
+            debitos.append(s12 * 0.12 + s11 * 0.11 + s11 * 0.01 + s19 * 0.19)
+            periodos.append((ano, mes))
+        resultados = _rollforward(credito_inicial, creditos, debitos, periodos)
+        total_pagar = sum(r["A Pagar"] for r in resultados)
+        for r in resultados:
             st.markdown(
-                """
-                <div style="
-                    text-align: center;
-                    padding: 16px;
-                    background: #2c3e50;
-                    border-radius: 12px;
-                    border: 2px dashed #7f8c8d;
-                ">
-                    <span style="color: #bdc3c7; font-size: 1.1em; font-weight: bold;">
-                        💡 Preencha pelo menos um campo para simular
-                    </span>
-                </div>
-                """,
-                unsafe_allow_html=True
+                f"<div style='background:#1a2433;border-radius:8px;padding:10px;margin-bottom:6px;'>"
+                f"<b>{r['Período']}</b> | Crédito Inicial {format_brl(r['Crédito Inicial'])} | "
+                f"Crédito do Mês {format_brl(r['Crédito do Mês'])} | Débito do Mês {format_brl(r['Débito do Mês'])} | "
+                f"A Pagar {format_brl(r['A Pagar'])} | Crédito Final {format_brl(r['Crédito Final'])}"
+                f"</div>",
+                unsafe_allow_html=True,
             )
+        st.metric("Total previsto a pagar (restante do ano)", format_brl(total_pagar))
 
-    # 3. MOSTRAR RESULTADOS APENAS APÓS SIMULAÇÃO
-    if st.session_state.simulacao_executada and tem_valores:
-        
-        # Cálculos (executados apenas quando necessário)
-        credito_4 = entrada_4 * 0.04
-        credito_7 = entrada_7 * 0.07
-        credito_12 = entrada_12 * 0.12
-        credito_19 = entrada_19 * 0.19
 
-        debito_12 = saida_12 * 0.12
-        debito_11 = saida_11 * 0.11
-        debito_protege = saida_11 * 0.01
-        debito_19 = saida_19 * 0.19
-
-        total_creditos = credito_4 + credito_7 + credito_12 + credito_19
-        total_debitos = debito_12 + debito_11 + debito_protege + debito_19
-        apuracao = credito_acumulado + total_creditos - total_debitos
-
-        # CARD GRANDE DO RESULTADO
-        cor_fundo = "#27ae60" if apuracao >= 0 else "#e74c3c"
-        
-        st.markdown(
-            f"""
-            <div style="
-                background: {cor_fundo};
-                border-radius: 16px;
-                padding: 24px;
-                text-align: center;
-                margin: 24px 0;
-                box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-                animation: slideIn 0.5s ease-out;
-            ">
-                <h2 style="color: white; margin: 0; font-size: 1.5em; font-weight: bold;">
-                    🎯 RESULTADO DA SIMULAÇÃO ICMS
-                </h2>
-                <div style="color: white; font-size: 2.5em; font-weight: bold; margin: 12px 0;">
-                    {format_brl(apuracao)}
-                </div>
-                <div style="color: white; font-size: 0.9em; margin-top: 8px; font-weight: bold;">
-                    Crédito acumulado atual: {format_brl(credito_acumulado)}
-                </div>
-            </div>
-            <style>
-                @keyframes slideIn {{
-                    from {{ opacity: 0; transform: translateY(-20px); }}
-                    to {{ opacity: 1; transform: translateY(0); }}
-                }}
-            </style>
-            """,
-            unsafe_allow_html=True
-        )
-
-        # RESULTADOS DETALHADOS
-        col_res1, col_res2 = st.columns(2, gap="large")
-        
-        with col_res1:
-            st.markdown(
-                """
-                <div style="
-                    background: #1a2433;
-                    border-radius: 12px;
-                    padding: 20px;
-                    border: 1px solid #2c3e50;
-                ">
-                    <h4 style="color: white; margin: 0 0 16px 0; font-weight: bold;">
-                        Créditos por ICMS
-                    </h4>
-                """,
-                unsafe_allow_html=True
-            )
-            
-            st.markdown(f"""
-                <div style="font-family: 'Segoe UI', sans-serif; line-height: 1.6;">
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">4%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(credito_4)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">7%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(credito_7)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">12%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(credito_12)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">19%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(credito_19)}</span>
-                    </div>
-                    <hr style="margin: 12px 0; border: none; border-top: 2px solid #ecf0f1;">
-                    <div style="display: flex; justify-content: space-between; font-weight: bold; font-size: 1.1em;">
-                        <span style="color: white;">Total:</span>
-                        <span style="color: white;">{format_brl(total_creditos)}</span>
-                    </div>
-                </div>
-            """, unsafe_allow_html=True)
-            
-            st.markdown("</div>", unsafe_allow_html=True)
-
-        with col_res2:
-            st.markdown(
-                """
-                <div style="
-                    background: #1a2433;
-                    border-radius: 12px;
-                    padding: 20px;
-                    border: 1px solid #2c3e50;
-                ">
-                    <h4 style="color: white; margin: 0 0 16px 0; font-weight: bold;">
-                        Débitos por ICMS
-                    </h4>
-                """,
-                unsafe_allow_html=True
-            )
-            
-            st.markdown(f"""
-                <div style="font-family: 'Segoe UI', sans-serif; line-height: 1.6;">
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">12%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(debito_12)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">11%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(debito_11)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">PROTEGE:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(debito_protege)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">19%:</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(debito_19)}</span>
-                    </div>
-                    <hr style="margin: 12px 0; border: none; border-top: 2px solid #ecf0f1;">
-                    <div style="display: flex; justify-content: space-between; font-weight: bold; font-size: 1.1em;">
-                        <span style="color: white;">Total:</span>
-                        <span style="color: white;">{format_brl(total_debitos)}</span>
-                    </div>
-                </div>
-            """, unsafe_allow_html=True)
-            
-            st.markdown("</div>", unsafe_allow_html=True)
-            
 def simulador_pis_cofins_manual(df=None, ano_sel=None, meses_sel=None):
     st.header("Simulação Manual de PIS/COFINS")
-
-    # Inicializar session_state
-    if 'entrada_pis_text' not in st.session_state:
-        st.session_state.entrada_pis_text = ""
-    if 'saida_pis_text' not in st.session_state:
-        st.session_state.saida_pis_text = ""
-    if 'simulacao_pis_executada' not in st.session_state:
-        st.session_state.simulacao_pis_executada = False
-
-    # Puxar crédito acumulado do último mês, se DataFrame for fornecido
-    credito_acumulado = 0.0
-    if df is not None and ano_sel is not None:
-        if meses_sel:
-            meses_param = meses_sel
-        else:
-            meses_param = list(range(1, 13))
-        todos_meses = calcular_resumo_fiscal_mes_a_mes(df, ano_sel, meses_param)
-        if todos_meses:
-            credito_acumulado = todos_meses[-1].get('Crédito PIS/COFINS Transportado', 0.0)
-
-    # Converter valores de texto para float
-    entrada_valor = moeda_to_float(st.session_state.entrada_pis_text)
-    saida_valor = moeda_to_float(st.session_state.saida_pis_text)
-
-    col_entradas, col_saidas = st.columns(2, gap="large")
-    with col_entradas:
-        st.markdown(
-            """
-            <div style="
-                background: #1a2433;
-                border-radius: 12px;
-                padding: 20px;
-                border: 1px solid #2c3e50;
-            ">
-                <h3 style="color: white; margin: 0 0 16px 0; font-size: 1.1em; font-weight: bold;">
-                    Entradas — Créditos PIS/COFINS
-                </h3>
-            """,
-            unsafe_allow_html=True
-        )
-        st.session_state.entrada_pis_text = st.text_input(
-            "Total Entradas (NFs com direito a crédito)", 
-            value=st.session_state.entrada_pis_text,
-            key="input_entrada_pis_text",
-            placeholder="Ex: 50000,00"
-        )
-        if st.session_state.entrada_pis_text:
-            st.markdown(f"<div style='color: #27ae60; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💰 {moeda_format(st.session_state.entrada_pis_text)}</div>", unsafe_allow_html=True)
-        st.markdown("</div>", unsafe_allow_html=True)
-    with col_saidas:
-        st.markdown(
-            """
-            <div style="
-                background: #1a2433;
-                border-radius: 12px;
-                padding: 20px;
-                border: 1px solid #2c3e50;
-            ">
-                <h3 style="color: white; margin: 0 0 16px 0; font-size: 1.1em; font-weight: bold;">
-                    Saídas — Débitos PIS/COFINS
-                </h3>
-            """,
-            unsafe_allow_html=True
-        )
-        st.session_state.saida_pis_text = st.text_input(
-            "Total Saídas (Faturamento tributado)", 
-            value=st.session_state.saida_pis_text,
-            key="input_saida_pis_text",
-            placeholder="Ex: 70000,00"
-        )
-        if st.session_state.saida_pis_text:
-            st.markdown(f"<div style='color: #e74c3c; font-weight: bold; margin-top: -10px; margin-bottom: 10px;'>💸 {moeda_format(st.session_state.saida_pis_text)}</div>", unsafe_allow_html=True)
-        st.markdown("</div>", unsafe_allow_html=True)
-
-    # Botão de simulação
-    st.markdown("<br>", unsafe_allow_html=True)
-    tem_valores = st.session_state.entrada_pis_text or st.session_state.saida_pis_text
-    col1, col2, col3 = st.columns([1, 2, 1])
-    with col2:
-        if tem_valores:
-            st.markdown("""
-            <div style="text-align: center; margin: 20px 0;">
-                <style>
-                    .btn-simular {
-                        background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
-                        border: 2px solid #1a2433;
-                        border-radius: 12px;
-                        color: white;
-                        padding: 16px 40px;
-                        font-size: 1.1em;
-                        font-weight: bold;
-                        cursor: pointer;
-                        transition: all 0.3s ease;
-                        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-                        text-transform: uppercase;
-                        letter-spacing: 1px;
-                        width: 100%;
-                        max-width: 300px;
-                    }
-                    .btn-simular:hover {
-                        background: linear-gradient(135deg, #34495e 0%, #2c3e50 100%);
-                        transform: translateY(-2px);
-                        box-shadow: 0 6px 16px rgba(0,0,0,0.25);
-                        border-color: #27ae60;
-                    }
-                    .btn-simular:active {
-                        transform: translateY(0);
-                        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-                    }
-                </style>
-            </div>
-            """, unsafe_allow_html=True)
-            simular = st.button(
-                "🔄 EXECUTAR SIMULAÇÃO",
-                key="btn_simular_pis",
-                use_container_width=True,
-                type="primary"
-            )
-            if simular:
-                st.session_state.simulacao_pis_executada = True
-                st.success("✅ Simulação executada com sucesso!")
-        else:
-            st.markdown("""
-                <div style="
-                    text-align: center;
-                    padding: 16px;
-                    background: #2c3e50;
-                    border-radius: 12px;
-                    border: 2px dashed #7f8c8d;
-                ">
-                    <span style="color: #bdc3c7; font-size: 1.1em; font-weight: bold;">
-                        💡 Preencha pelo menos um campo para simular
-                    </span>
-                </div>
-            """, unsafe_allow_html=True)
-
-    # Resultado apenas se simulado
-    if st.session_state.simulacao_pis_executada and tem_valores:
-        credito_entradas = entrada_valor * 0.0925
-        debito_saidas = saida_valor * 0.0925
-        apuracao = credito_acumulado + credito_entradas - debito_saidas
-        cor_fundo = "#27ae60" if apuracao >= 0 else "#e74c3c"
-        st.markdown(
-            f"""
-            <div style="
-                background: {cor_fundo};
-                border-radius: 16px;
-                padding: 24px;
-                text-align: center;
-                margin: 24px 0;
-                box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-                animation: slideIn 0.5s ease-out;
-            ">
-                <h2 style="color: white; margin: 0; font-size: 1.5em; font-weight: bold;">
-                    🎯 RESULTADO DA SIMULAÇÃO PIS/COFINS
-                </h2>
-                <div style="color: white; font-size: 2.5em; font-weight: bold; margin: 12px 0;">
-                    {format_brl(apuracao)}
-                </div>
-                <div style="color: white; font-size: 0.9em; margin-top: 8px; font-weight: bold;">
-                    Crédito acumulado atual: {format_brl(credito_acumulado)}
-                </div>
-            </div>
-            <style>
-                @keyframes slideIn {{
-                    from {{ opacity: 0; transform: translateY(-20px); }}
-                    to {{ opacity: 1; transform: translateY(0); }}
-                }}
-            </style>
-            """,
-            unsafe_allow_html=True
-        )
-
-        col_res1, col_res2 = st.columns(2, gap="large")
-        with col_res1:
+    ano_vig, mes_vig = _ultimo_mes_vigente(df if df is not None else pd.DataFrame())
+    credito_inicial = _credito_acumulado_atual(df, ano_vig, mes_vig, "pc")
+    st.markdown(f"Mês vigente: **{MESES_PT[mes_vig]} / {ano_vig}**")
+    st.markdown(f"Crédito acumulado inicial: **{format_brl(credito_inicial)}**")
+    meses = _meses_restantes_do_ano(ano_vig, mes_vig)
+    valores = {}
+    for ano, mes in meses:
+        with st.expander(f"{MESES_PT[mes]}/{ano}", expanded=(mes == mes_vig)):
+            base_ent = st.number_input("Base Entradas", min_value=0.0, key=f"pc_{ano}_{mes}_be")
+            base_sai = st.number_input("Base Saídas", min_value=0.0, key=f"pc_{ano}_{mes}_bs")
+            valores[(ano, mes)] = (base_ent, base_sai)
+    if st.button("Simular projeção", key="btn_pc_proj"):
+        creditos, debitos, periodos = [], [], []
+        for (ano, mes), (be, bs) in valores.items():
+            creditos.append(be * 0.0925)
+            debitos.append(bs * 0.0925)
+            periodos.append((ano, mes))
+        resultados = _rollforward(credito_inicial, creditos, debitos, periodos)
+        total_pagar = sum(r["A Pagar"] for r in resultados)
+        for r in resultados:
             st.markdown(
-                """
-                <div style="
-                    background: #1a2433;
-                    border-radius: 12px;
-                    padding: 20px;
-                    border: 1px solid #2c3e50;
-                ">
-                    <h4 style="color: white; margin: 0 0 16px 0; font-weight: bold;">
-                        Créditos de PIS/COFINS
-                    </h4>
-                """,
-                unsafe_allow_html=True
+                f"<div style='background:#1a2433;border-radius:8px;padding:10px;margin-bottom:6px;'>"
+                f"<b>{r['Período']}</b> | Crédito Inicial {format_brl(r['Crédito Inicial'])} | "
+                f"Crédito do Mês {format_brl(r['Crédito do Mês'])} | Débito do Mês {format_brl(r['Débito do Mês'])} | "
+                f"A Pagar {format_brl(r['A Pagar'])} | Crédito Final {format_brl(r['Crédito Final'])}"
+                f"</div>",
+                unsafe_allow_html=True,
             )
-            st.markdown(f"""
-                <div style="font-family: 'Segoe UI', sans-serif; line-height: 1.6;">
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">Total Entradas:</span>
-                        <span style="color: white; font-weight: bold;">{moeda_format(st.session_state.entrada_pis_text)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">Crédito PIS/COFINS (9,25%):</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(credito_entradas)}</span>
-                    </div>
-                </div>
-            """, unsafe_allow_html=True)
-            st.markdown("</div>", unsafe_allow_html=True)
-        with col_res2:
-            st.markdown(
-                """
-                <div style="
-                    background: #1a2433;
-                    border-radius: 12px;
-                    padding: 20px;
-                    border: 1px solid #2c3e50;
-                ">
-                    <h4 style="color: white; margin: 0 0 16px 0; font-weight: bold;">
-                        Débitos de PIS/COFINS
-                    </h4>
-                """,
-                unsafe_allow_html=True
-            )
-            st.markdown(f"""
-                <div style="font-family: 'Segoe UI', sans-serif; line-height: 1.6;">
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">Total Saídas:</span>
-                        <span style="color: white; font-weight: bold;">{moeda_format(st.session_state.saida_pis_text)}</span>
-                    </div>
-                    <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
-                        <span style="color: white; font-weight: bold;">Débito PIS/COFINS (9,25%):</span>
-                        <span style="color: white; font-weight: bold;">{format_brl(debito_saidas)}</span>
-                    </div>
-                </div>
-            """, unsafe_allow_html=True)
-            st.markdown("</div>", unsafe_allow_html=True)
+        st.metric("Total previsto a pagar (restante do ano)", format_brl(total_pagar))
+

--- a/relatorio_graficos.py
+++ b/relatorio_graficos.py
@@ -230,8 +230,8 @@ def mostrar_entradas_saidas(
     df_ent = prepara(df_entradas, True)
     df_sai = prepara(df_saidas, False)
 
-    mostrar_por_mes = set(meses_num) == set(range(1, 13))
-    idx = range(1, 13) if mostrar_por_mes else sorted(meses_num)
+    is_full_year = set(meses_num) == set(range(1, 13))
+    idx = range(1, 13) if is_full_year else sorted(meses_num)
 
     ent_mes = (
         df_ent.groupby(df_ent["Data Emissão"].dt.month)["Valor Líquido"].sum()
@@ -263,6 +263,8 @@ def mostrar_entradas_saidas(
         '<h2 class="section-title">Entradas x Saídas por Período</h2>',
         unsafe_allow_html=True,
     )
+
+    if is_full_year:
         df_plot = df_mes.melt(
             id_vars=["Mês"],
             value_vars=["Entradas", "Saídas"],


### PR DESCRIPTION
## Summary
- allow manual future month simulation for ICMS
- add manual month projection for PIS/COFINS
- fix indentation in mostrar_entradas_saidas to resolve unexpected indent

## Testing
- `python -m py_compile relatorio_fiscal.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9dce048c8326a5eb8687c3188019